### PR TITLE
Refactor AuthWrapper to improve authentication handling

### DIFF
--- a/src/components/AuthWrapper.tsx
+++ b/src/components/AuthWrapper.tsx
@@ -36,9 +36,18 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
     );
   }
 
-  // Show login page if on login route or not authenticated
-  if (pathname === '/login' || !isAuthenticated) {
+  // Only show login page if explicitly on login route
+  if (pathname === '/login') {
     return <>{children}</>;
+  }
+
+  // Show loading screen if not authenticated (prevents flash while redirecting)
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <Heart className="w-12 h-12 text-red-500 fill-red-500 animate-heartbeat" strokeWidth={1} />
+      </div>
+    );
   }
 
   // Show protected content if authenticated


### PR DESCRIPTION
- Updated AuthWrapper to only show the login page when explicitly on the '/login' route.
- Added a loading screen for unauthenticated users to prevent flash during redirection.
- Cleaned up the logic for rendering protected content based on authentication state.

This change enhances the user experience by providing clearer authentication flow and visual feedback.